### PR TITLE
feat: add proxy for https

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 module.exports = {
   reactStrictMode: true,
   async rewrites() {
-    return []; // 리라이트 설정 제거
+    return [
+      {
+        source: "/api/:path*", // 프론트엔드에서 사용하는 API 경로
+        destination: "http://api.ai-tutor.co.kr:8080/api/:path*", // 백엔드 실제 경로
+      },
+    ];
   },
 };


### PR DESCRIPTION
### PR 설명
문제 요약
현재 https://www.ai-tutor.co.kr에서 Mixed Content 문제가 발생하고 있습니다. 이는 프론트엔드가 HTTPS를 사용하는 반면, 백엔드 API는 HTTP를 사용하여 요청이 차단되는 문제입니다.

### 해결 방법
Proxy 설정: next.config.js에 rewrites를 추가하여 HTTPS를 사용하는 프론트엔드가 백엔드 HTTP 요청을 내부적으로 처리하도록 프록시를 설정했습니다.

### 적용 사항
프론트엔드에서 사용하는 /api 경로를 백엔드의 HTTP API로 프록시 처리합니다.
변경된 설정은 임시적인 우회책이며, 백엔드에 HTTPS 설정이 완료된 후 제거될 예정입니다.