### PR TITLE
[FEAT] 디자인 리펙토링 (Button Disabled issue, alert -> toast)

### DIFF
--- a/src/app/(routes)/notes/[folderId]/[noteId]/confirm/page.tsx
+++ b/src/app/(routes)/notes/[folderId]/[noteId]/confirm/page.tsx
@@ -1,14 +1,14 @@
-"use client";
-import { useEffect, useState } from "react";
-import Button from "@/app/components/atoms/Button";
-import TextInputSection from "@/app/components/atoms/TextInputSection";
-import { usePracticeContext } from "@/app/context/PracticeContext";
-import { createSTT, summaryNote } from "@/app/api/notes";
-import { useParams, useRouter } from "next/navigation";
-import Image from "next/image";
-import toast from "react-hot-toast";
+'use client';
+import { useEffect, useState } from 'react';
+import Button from '@/app/components/atoms/Button';
+import TextInputSection from '@/app/components/atoms/TextInputSection';
+import { usePracticeContext } from '@/app/context/PracticeContext';
+import { createSTT, summaryNote } from '@/app/api/notes';
+import { useParams, useRouter } from 'next/navigation';
+import Image from 'next/image';
+import toast from 'react-hot-toast';
 
-import Loader, { SmallLoader } from "@/app/components/utils/Loader";
+import Loader, { SmallLoader } from '@/app/components/utils/Loader';
 
 const ConfirmNotePage = () => {
   const {
@@ -45,8 +45,9 @@ const ConfirmNotePage = () => {
   }, [file, folderId, noteId, setSttLoading]);
 
   const handleNoteFinalBtn = async () => {
+    if (summaryLoading || sttLoading) return;
     if (!keywords || !requirement) {
-      toast.error("키워드와 요구사항을 모두 입력해주세요.");
+      toast.error('키워드와 요구사항을 모두 입력해주세요.');
       return;
     }
     setSummaryLoading(true);
@@ -97,12 +98,12 @@ const ConfirmNotePage = () => {
             </p>
             <p
               className={`text-base border-[0.5px] py-3 px-4 w-full border-black-80 rounded-md p-2 text-black-70 flex font-semibold gap-4 transition-colors duration-300 ${
-                !sttLoading && file ? "bg-primary/10" : ""
+                !sttLoading && file ? 'bg-primary/10' : ''
               }`}
             >
               <Image
                 src={`/active_folder.svg`}
-                alt={"active_folder"}
+                alt={'active_folder'}
                 width={40}
                 height={40}
               />
@@ -112,7 +113,7 @@ const ConfirmNotePage = () => {
                     {file?.name && (
                       <>
                         {file.name.slice(0, 15)}
-                        {file.name.length > 15 && "..."}
+                        {file.name.length > 15 && '...'}
                       </>
                     )}
                     {sttLoading && <SmallLoader />}

--- a/src/app/(routes)/notes/[folderId]/[noteId]/create-practice/page.tsx
+++ b/src/app/(routes)/notes/[folderId]/[noteId]/create-practice/page.tsx
@@ -1,15 +1,15 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { usePracticeContext } from "@/app/context/PracticeContext";
-import NewPracticeForm from "@/app/components/organisms/NewPracticeForm";
-import Button from "@/app/components/atoms/Button";
-import { createPractice } from "@/app/api/practice/createPractice";
-import Loader from "@/app/components/utils/Loader";
-import { createSTT } from "@/app/api/notes";
-import { toast } from "react-hot-toast";
-import axios from "axios";
+import React, { useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { usePracticeContext } from '@/app/context/PracticeContext';
+import NewPracticeForm from '@/app/components/organisms/NewPracticeForm';
+import Button from '@/app/components/atoms/Button';
+import { createPractice } from '@/app/api/practice/createPractice';
+import Loader from '@/app/components/utils/Loader';
+import { createSTT } from '@/app/api/notes';
+import { toast } from 'react-hot-toast';
+import axios from 'axios';
 
 interface CreatePracticeApiResponse {
   check: boolean;
@@ -43,12 +43,12 @@ const CreatePracticePage = () => {
 
   const handleCreatePractice = async () => {
     if (!noteId || !file || file.size === 0) {
-      alert("파일이 업로드되지 않았습니다. 파일을 선택해주세요.");
+      toast.error('파일이 업로드되지 않았습니다. 파일을 선택해주세요.');
       return;
     }
 
     if (!type) {
-      alert("문제 유형을 최소 하나 선택해야 합니다.");
+      toast.error('문제 유형을 최소 하나 선택해야 합니다.');
       return;
     }
 
@@ -70,7 +70,7 @@ const CreatePracticePage = () => {
       const createRes: CreatePracticeApiResponse = await createPractice(
         createPayLoad
       );
-      toast.success("문제 생성이 완료되었습니다.");
+      toast.success('문제 생성이 완료되었습니다.');
 
       setQuestions(createRes.information.practiceResList);
       setSummary(createRes.information.summary);
@@ -80,7 +80,7 @@ const CreatePracticePage = () => {
       if (axios.isAxiosError(error)) {
         toast.error(
           `API 에러: ${
-            error.response?.data?.message || "알 수 없는 오류가 발생했습니다."
+            error.response?.data?.message || '알 수 없는 오류가 발생했습니다.'
           }`
         );
       } else {
@@ -88,7 +88,7 @@ const CreatePracticePage = () => {
           `오류 발생: ${
             error instanceof Error
               ? error.message
-              : "알 수 없는 오류가 발생했습니다."
+              : '알 수 없는 오류가 발생했습니다.'
           }`
         );
       }

--- a/src/app/api/summaries/fetchSummary.ts
+++ b/src/app/api/summaries/fetchSummary.ts
@@ -1,8 +1,7 @@
-import axios from "axios";
-import { baseURL } from "..";
-import apiClient from "@/app/utils/api";
+import axios from 'axios';
+import { baseURL } from '..';
+import apiClient from '@/app/utils/api';
 
-// Only noteId is required for fetching summary
 interface FetchSummaryRequest {
   folderId: number;
   noteId: number;
@@ -17,13 +16,13 @@ export const fetchSummary = async ({
       `/api/v1/folders/${folderId}/notes/${noteId}/summaries`,
       {
         headers: {
-          "Content-Type": "application/json",
+          'Content-Type': 'application/json',
         },
       }
     );
     return response.data;
   } catch (error) {
-    console.error("노트 요약문 조회 실패:", error);
+    console.error('노트 요약문 조회 실패:', error);
     throw error;
   }
 };

--- a/src/app/api/summaries/index.ts
+++ b/src/app/api/summaries/index.ts
@@ -12,30 +12,25 @@ interface PostSummaryProps {
   noteId: number; // 동적으로 noteId를 받아오도록 추가
 }
 
-// 파일과 JSON 데이터를 함께 서버로 전송하는 함수
 export const postSummary = async ({ file, request }: PostSummaryProps) => {
-  // FormData 객체 생성
   const formData = new FormData();
 
-  // 파일을 FormData에 추가
   formData.append('file', file);
 
-  // JSON 데이터를 문자열로 변환 후 FormData에 추가
   formData.append(
     'createPracticeReq',
     new Blob([JSON.stringify(request)], {
-      type: 'application/json', // Blob을 올바른 MIME 타입으로 생성
+      type: 'application/json',
     })
   );
 
   try {
-    // 서버로 POST 요청 보내기
     const response = await apiClient.post(
-      `/api/v1/professor/practice`, // 동적으로 `noteId` 사용
+      `/api/v1/professor/practice`,
       formData,
       {
         headers: {
-          'Content-Type': 'multipart/form-data', // FormData를 전송할 때 올바른 Content-Type 설정
+          'Content-Type': 'multipart/form-data',
         },
       }
     );

--- a/src/app/components/atoms/Button.tsx
+++ b/src/app/components/atoms/Button.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import Image from "next/image";
+import React from 'react';
+import Image from 'next/image';
 
 interface ButtonProps {
   label?: string;
@@ -10,43 +10,57 @@ interface ButtonProps {
   onClick?: () => void;
   onMouseEnter?: () => void;
   onMouseLeave?: () => void;
-  type?: "button" | "submit" | "reset";
-  variant?: "select" | "next" | "create" | "cancel" | "save";
-  iconPosition?: "left" | "right";
+  type?: 'button' | 'submit' | 'reset';
+  variant?: 'select' | 'next' | 'create' | 'cancel' | 'save';
+  iconPosition?: 'left' | 'right';
   className?: string;
 }
 
 const Button: React.FC<ButtonProps> = ({
-  label = "",
+  label = '',
   disabled = false,
   imgSrc,
-  imgAlt = "icon",
+  imgAlt = 'icon',
   isSelected = false,
   onClick,
   onMouseEnter,
   onMouseLeave,
-  type = "button",
-  variant = "create",
-  iconPosition = "right",
-  className = "",
+  type = 'button',
+  variant = 'create',
+  iconPosition = 'right',
+  className = '',
 }) => {
   const getButtonStyles = () => {
+    let base = '';
+
     switch (variant) {
-      case "select":
-        return `rounded-full w-full transition-all duration-300 ease-in-out transform ${
-          isSelected ? "bg-primary shadow-lg" : "bg-black-80 opacity-80"
+      case 'select':
+        base = `rounded-full w-full transition-all duration-300 ease-in-out transform ${
+          isSelected ? 'bg-primary shadow-lg' : 'bg-black-80 opacity-80'
         }`;
-      case "next":
-        return `rounded-full border-black-70 border hover:bg-black-80 transition-all duration-300 ease-in-out`;
-      case "create":
-        return `bg-black-70 rounded-full border border-black-60 hover:bg-black-80 transition-all duration-300`;
-      case "cancel":
-        return `bg-[#3F3F3F] rounded-[10px] border border-[#565656] hover:bg-[#222222] transition-all duration-300`;
-      case "save":
-        return `bg-mainGreen rounded-[10px] border border-[#4CE5A9] hover:bg-[#00A264] transition-all duration-300`;
+        break;
+      case 'next':
+        base = `rounded-full border-black-70 border hover:bg-black-80 transition-all duration-300 ease-in-out`;
+        break;
+      case 'create':
+        base = `bg-black-70 rounded-full border border-black-60 hover:bg-black-80 transition-all duration-300`;
+        break;
+      case 'cancel':
+        base = `bg-[#3F3F3F] rounded-[10px] border border-[#565656] hover:bg-[#222222] transition-all duration-300`;
+        break;
+      case 'save':
+        base = `bg-mainGreen rounded-[10px] border border-[#4CE5A9] hover:bg-[#00A264] transition-all duration-300`;
+        break;
       default:
-        return "";
+        base = '';
     }
+
+    if (disabled) {
+      base +=
+        ' opacity-40 grayscale brightness-75 cursor-not-allowed pointer-events-none';
+    }
+
+    return base;
   };
 
   return (
@@ -58,7 +72,7 @@ const Button: React.FC<ButtonProps> = ({
       onMouseLeave={onMouseLeave}
       disabled={disabled}
     >
-      {imgSrc && iconPosition === "left" && (
+      {imgSrc && iconPosition === 'left' && (
         <Image src={`/${imgSrc}.svg`} alt={imgAlt} width={16} height={16} />
       )}
 
@@ -66,7 +80,7 @@ const Button: React.FC<ButtonProps> = ({
         {label}
       </p>
 
-      {imgSrc && iconPosition === "right" && (
+      {imgSrc && iconPosition === 'right' && (
         <Image src={`/${imgSrc}.svg`} alt={imgAlt} width={10} height={10} />
       )}
     </button>

--- a/src/app/components/atoms/CountInput.tsx
+++ b/src/app/components/atoms/CountInput.tsx
@@ -1,5 +1,6 @@
-import React from "react";
-import { FormInput } from "../atoms/FormInput";
+import React from 'react';
+import { FormInput } from '../atoms/FormInput';
+import { toast } from 'react-hot-toast';
 
 interface CountInputProps {
   name: string;
@@ -11,15 +12,15 @@ interface CountInputProps {
 
 const CountInput: React.FC<CountInputProps> = ({
   name,
-  defaultValue = "",
-  placeholder = "",
+  defaultValue = '',
+  placeholder = '',
   onChange,
   disabled = false,
 }) => {
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = Number(event.target.value);
     if (value > 20) {
-      alert("20개 이하로 입력해 주세요.");
+      toast.error('20개 이하로 입력해 주세요.');
       return;
     }
     onChange(event);


### PR DESCRIPTION
<img width="839" alt="스크린샷 2025-06-21 오후 9 25 05" src="https://github.com/user-attachments/assets/dbd0a9b3-f59a-4d96-89c0-2a754a3faec2" />
<img width="788" alt="스크린샷 2025-06-21 오후 9 25 19" src="https://github.com/user-attachments/assets/02ef0de9-7a5e-4df7-84c5-244de7e98e46" />

stt Loading 전, button disabled가 안 먹혔던 이슈해결했으며
에러메세지 형식 통일했습니다!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error notifications by replacing browser alerts with toast notifications in practice creation and count input components.
	- Prevented multiple concurrent submissions in note confirmation by blocking button actions while loading.

- **Style**
	- Standardized use of single quotes for all string literals and JSX attributes across multiple components for consistency.
	- Minor formatting updates to improve code readability.

- **Refactor**
	- Updated button styling logic to better handle disabled states and allow conditional style appending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->