### PR TITLE
[Feat] Guide onboarding modal 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react-hot-toast": "^2.5.2",
         "react-slick": "^0.30.3",
         "slick-carousel": "^1.8.1",
-        "zustand": "^5.0.0-rc.2"
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -7238,9 +7238,9 @@
       "license": "MIT"
     },
     "node_modules/zustand": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
-      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-hot-toast": "^2.5.2",
     "react-slick": "^0.30.3",
     "slick-carousel": "^1.8.1",
-    "zustand": "^5.0.0-rc.2"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/src/app/(routes)/home/page.tsx
+++ b/src/app/(routes)/home/page.tsx
@@ -27,6 +27,7 @@ import toast from 'react-hot-toast';
 
 const HomePage = () => {
   const { data: session, status } = useSession();
+
   const token = session?.user?.aiTutorToken;
   const { data: folders = [] } = useFetchFolders({
     enabled: status === 'authenticated' && !!token,
@@ -34,7 +35,7 @@ const HomePage = () => {
   const createFolder = useCreateFolder();
   const updateFolder = useUpdateFolder();
   const deleteFolder = useDeleteFolder();
-  const { open } = useOnboardingstore();
+  const { isOpen, open } = useOnboardingstore();
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [showModify, setShowModify] = useState<{ [key: string]: boolean }>({});
   const [showModal, setShowModal] = useState(false);
@@ -122,7 +123,7 @@ const HomePage = () => {
 
         <div className="bg-black-80 rounded-lg rounded-b-none mx-4 h-full">
           <div className="flex text-center">
-            {showOnboarding && <OnBoardingModal></OnBoardingModal>}
+            {isOpen && <OnBoardingModal></OnBoardingModal>}
           </div>
           {folders.length === 0 ? (
             <div className="flex flex-col justify-center items-center h-full text-center text-white">

--- a/src/app/(routes)/home/page.tsx
+++ b/src/app/(routes)/home/page.tsx
@@ -1,50 +1,55 @@
-"use client";
-import React, { useState } from "react";
-import Button from "@/app/components/atoms/Button";
+'use client';
+import React, { useEffect, useState } from 'react';
+import Button from '@/app/components/atoms/Button';
 import {
   SectionFolder,
   SectionModal,
   SectionModify,
-} from "@/app/components/molecules/Modal";
-import { useFetchFolders } from "@/app/hooks/folder/useFetchFolders";
-import { useCreateFolder } from "@/app/hooks/folder/useCreateFolder";
-import { useUpdateFolder } from "@/app/hooks/folder/useUpdateFolder";
-import { useDeleteFolder } from "@/app/hooks/folder/useDeleteFolder";
-import { useSession } from "next-auth/react";
-import Image from "next/image";
-import speach_bubble from "../../../../public/speech_bubble.svg";
-import { Folder } from "@/app/types/folder";
+} from '@/app/components/molecules/Modal';
+import {
+  getIsFirstTimeUser,
+  setIsFirstTimeUser,
+} from '@/app/utils/localstorage';
+import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
+import { useCreateFolder } from '@/app/hooks/folder/useCreateFolder';
+import { useUpdateFolder } from '@/app/hooks/folder/useUpdateFolder';
+import { useDeleteFolder } from '@/app/hooks/folder/useDeleteFolder';
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import speach_bubble from '../../../../public/speech_bubble.svg';
+import { Folder } from '@/app/types/folder';
 
-import { useOnboarding } from "@/app/hooks/useOnboarding";
+import { useOnboarding } from '@/app/hooks/useOnboarding';
 
-import OnBoardingModal from "@/app/components/molecules/OnBoardingModal";
-import toast from "react-hot-toast";
+import OnBoardingModal from '@/app/components/molecules/OnBoardingModal';
+import toast from 'react-hot-toast';
 
 const HomePage = () => {
   const { data: session, status } = useSession();
   const token = session?.user?.aiTutorToken;
   const { data: folders = [] } = useFetchFolders({
-    enabled: status === "authenticated" && !!token,
+    enabled: status === 'authenticated' && !!token,
   });
   const createFolder = useCreateFolder();
   const updateFolder = useUpdateFolder();
   const deleteFolder = useDeleteFolder();
-
+  const { open } = useOnboardingstore();
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [showModify, setShowModify] = useState<{ [key: string]: boolean }>({});
   const [showModal, setShowModal] = useState(false);
-  const [subject, setSubject] = useState("");
-  const [professor, setProfessor] = useState("");
+  const [subject, setSubject] = useState('');
+  const [professor, setProfessor] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
 
   const handleCreateFolder = async (): Promise<boolean> => {
     if (!subject) {
-      toast.error("과목명을 입력해주세요.");
+      toast.error('과목명을 입력해주세요.');
       return false;
     }
 
     if (!professor) {
-      toast.error("교수명을 입력해주세요.");
+      toast.error('교수명을 입력해주세요.');
       return false;
     }
 
@@ -52,8 +57,8 @@ const HomePage = () => {
       folderName: subject,
       professorName: professor,
     });
-    setSubject("");
-    setProfessor("");
+    setSubject('');
+    setProfessor('');
     return true;
   };
 
@@ -76,6 +81,13 @@ const HomePage = () => {
     setSelectedFolder(null);
   };
   const { showOnboarding, closeOnboarding } = useOnboarding();
+
+  useEffect(() => {
+    if (getIsFirstTimeUser()) {
+      open();
+      setIsFirstTimeUser(false);
+    }
+  }, []);
 
   return (
     <div className="flex flex-col justify-between h-full w-full">
@@ -100,8 +112,8 @@ const HomePage = () => {
               variant="create"
               onClick={() => {
                 setIsEditMode(false);
-                setSubject("");
-                setProfessor("");
+                setSubject('');
+                setProfessor('');
                 setShowModal(true);
               }}
             />
@@ -110,9 +122,7 @@ const HomePage = () => {
 
         <div className="bg-black-80 rounded-lg rounded-b-none mx-4 h-full">
           <div className="flex text-center">
-            {showOnboarding && (
-              <OnBoardingModal onClose={closeOnboarding}></OnBoardingModal>
-            )}
+            {showOnboarding && <OnBoardingModal></OnBoardingModal>}
           </div>
           {folders.length === 0 ? (
             <div className="flex flex-col justify-center items-center h-full text-center text-white">

--- a/src/app/(routes)/layout.tsx
+++ b/src/app/(routes)/layout.tsx
@@ -1,25 +1,26 @@
-"use client";
+'use client';
 
-import Sidebar from "@/app/components/utils/Sidebar";
-import { PracticeProvider } from "@/app/context/PracticeContext";
-import { usePathname } from "next/navigation";
-import "@/app/globals.css";
-import { Toaster } from "react-hot-toast";
-import useAuthInterceptor from "../hooks/auth/useAuthInterceptor";
-
+import Sidebar from '@/app/components/utils/Sidebar';
+import { PracticeProvider } from '@/app/context/PracticeContext';
+import { usePathname } from 'next/navigation';
+import '@/app/globals.css';
+import { Toaster } from 'react-hot-toast';
+import useAuthInterceptor from '../hooks/auth/useAuthInterceptor';
+import OnBoardingModal from '../components/molecules/OnBoardingModal';
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const isLoginPage = pathname.startsWith("/login");
+  const isLoginPage = pathname.startsWith('/login');
 
   useAuthInterceptor();
 
   return (
     <div>
       <PracticeProvider>
+        <OnBoardingModal />
         <Toaster />
         <div className="flex bg-black">
           {!isLoginPage && <Sidebar />}

--- a/src/app/components/molecules/OnBoardingModal.tsx
+++ b/src/app/components/molecules/OnBoardingModal.tsx
@@ -1,24 +1,23 @@
 import React, { useState } from 'react';
-
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
 import Image from 'next/image';
 import OnBoardingCarousel from './OnBoardingCarousel';
 import { slides } from '@/app/constants/OnBoardingModalImageList';
 
-interface OnBoardingModalProps {
-  onClose: () => void;
-}
-
-const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
+const OnBoardingModal: React.FC = () => {
   const [slideIndex, setSlideIndex] = useState(0);
 
   const handleSlideClicked = (index: number) => {
     setSlideIndex(index);
   };
 
+  const { isOpen, close } = useOnboardingstore();
+
+  if (!isOpen) return null;
   return (
     <div
       className="fixed flex flex-col z-50 inset-0 items-center justify-center bg-black bg-opacity-50 backdrop-blur-md"
-      onClick={onClose}
+      onClick={close}
     >
       <div
         onClick={(e) => e.stopPropagation()}
@@ -41,7 +40,7 @@ const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
         ></OnBoardingCarousel>{' '}
         <button
           className="absolute top-4 right-1 bg-transparent text-white px-3 py-1 rounded-md"
-          onClick={onClose}
+          onClick={close}
         >
           ✕
         </button>

--- a/src/app/components/molecules/OnBoardingModal.tsx
+++ b/src/app/components/molecules/OnBoardingModal.tsx
@@ -6,11 +6,9 @@ import { slides } from '@/app/constants/OnBoardingModalImageList';
 
 interface OnBoardingModalProps {
   onClose: () => void;
-  //필요 props 추가할거 있으면 해야할듯 합니다.
 }
 
 const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
-  //carousel IMG Array
   const [slideIndex, setSlideIndex] = useState(0);
 
   const handleSlideClicked = (index: number) => {

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useOnboarding } from '@/app/hooks/useOnboarding';
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
 import Link from 'next/link';
 import Icon from '../atoms/Icon';
 import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
@@ -12,7 +12,7 @@ const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
-  const { showOnboarding, closeOnboarding } = useOnboarding();
+  const { isOpen, close, open } = useOnboardingstore();
 
   useEffect(() => {
     if (token) {
@@ -22,7 +22,7 @@ const Sidebar: React.FC = () => {
   }, [token]);
 
   const handleGuideClick = () => {
-    //클릭 누르면 글로벌 상태 변경
+    open();
   };
 
   const { data: folders = [], isLoading, error } = useFetchFolders();
@@ -86,7 +86,10 @@ const Sidebar: React.FC = () => {
       </div>
       <div className="pb-8">
         <div className="hover:bg-black-80 hover:rounded-md cursor-pointer transition-colors duration-200 rounded-md">
-          <div className="flex flex-row px-[35px] py-2 gap-3">
+          <div
+            onClick={handleGuideClick}
+            className="flex flex-row px-[35px] py-2 gap-3"
+          >
             <Icon label="guide" className="w-[20px] h-[20px] my-auto" />
             <p className="text-white">가이드보기</p>
           </div>

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -1,16 +1,18 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import Icon from "../atoms/Icon";
-import { useFetchFolders } from "@/app/hooks/folder/useFetchFolders";
-import { setAuthToken } from "@/app/utils/api";
-import { useSession } from "next-auth/react";
+import { useEffect, useState } from 'react';
+import { useOnboarding } from '@/app/hooks/useOnboarding';
+import Link from 'next/link';
+import Icon from '../atoms/Icon';
+import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
+import { setAuthToken } from '@/app/utils/api';
+import { useSession } from 'next-auth/react';
 
 const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
+  const { showOnboarding, closeOnboarding } = useOnboarding();
 
   useEffect(() => {
     if (token) {
@@ -18,6 +20,10 @@ const Sidebar: React.FC = () => {
       setIsAuthSet(true);
     }
   }, [token]);
+
+  const handleGuideClick = () => {
+    //클릭 누르면 글로벌 상태 변경
+  };
 
   const { data: folders = [], isLoading, error } = useFetchFolders();
 
@@ -57,7 +63,7 @@ const Sidebar: React.FC = () => {
               <Icon
                 label="arrow_sidebar"
                 className={`h-[16px] w-[16px] my-auto invert transition-transform ${
-                  showSections ? "rotate-90" : ""
+                  showSections ? 'rotate-90' : ''
                 }`}
               />
             </div>

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -12,7 +12,7 @@ const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
-  const { isOpen, close, open } = useOnboardingstore();
+  const { open } = useOnboardingstore();
 
   useEffect(() => {
     if (token) {
@@ -22,6 +22,8 @@ const Sidebar: React.FC = () => {
   }, [token]);
 
   const handleGuideClick = () => {
+    console.log('클릭');
+
     open();
   };
 
@@ -87,7 +89,9 @@ const Sidebar: React.FC = () => {
       <div className="pb-8">
         <div className="hover:bg-black-80 hover:rounded-md cursor-pointer transition-colors duration-200 rounded-md">
           <div
-            onClick={handleGuideClick}
+            onClick={() => {
+              handleGuideClick();
+            }}
             className="flex flex-row px-[35px] py-2 gap-3"
           >
             <Icon label="guide" className="w-[20px] h-[20px] my-auto" />

--- a/src/app/store/useOnboardingStore.ts
+++ b/src/app/store/useOnboardingStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface OnboardingStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useOnboardingstore = create<OnboardingStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## 🔍 관련 이슈
- close #75 

## 🌏 Summary
원래 최초 진입시에만 가이드를 보여주고 안보여줬던 거에 더해
가이드 보기를 수동으로 사용자가 누르면 만들어뒀던 온보딩 모달을 띄우게 했습니다.

이를 위해 zustand 전역상태를 추가한점 알려드립니다
## 📸 스크린샷

## 🤔 고민했던 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an onboarding guide that appears for first-time users and can be accessed anytime from the sidebar.
- **Improvements**
  - Simplified onboarding modal behavior for a more seamless user experience.
- **Chores**
  - Updated a core dependency to a stable version for improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->