### PR TITLE
[FEAT] 내부 노트 조회 API 연동 및 폴더/노트 인터랙션 구현

### DIFF
--- a/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
+++ b/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+
 import React, { useEffect, useState, useRef } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { fetchSummary } from "@/app/api/summaries/fetchSummary";
@@ -6,14 +7,51 @@ import Icon from "@/app/components/atoms/Icon";
 import Button from "@/app/components/atoms/Button";
 import { PDFDownloadLink } from "@react-pdf/renderer";
 import { SummaryPDFDocument } from "@/app/utils/pdfExportSummary";
+import { getPractice } from "@/app/api/practice/getPractice";
+import { useSession } from "next-auth/react";
 
 export default function SummaryPage() {
   const { folderId, noteId } = useParams();
   const router = useRouter();
+
   const [summary, setSummary] = useState("");
   const [loading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [practiceQuestions, setPracticeQuestions] = useState<any[]>([]);
   const leftAreaRef = useRef<HTMLDivElement>(null);
   const [leftWidth, setLeftWidth] = useState<number | null>(null);
+  const { data: session, status } = useSession();
+  const token = session?.user?.aiTutorToken;
+  const setAuthToken = (token: string | null) => {
+    if (token) {
+      localStorage.setItem("aiTutorToken", token);
+    }}
+
+
+
+  useEffect(() => {
+  const fetchPractice = async () => {
+    try {
+      setIsLoading(true);
+      const data = await getPractice(Number(noteId));
+      setPracticeQuestions(data?.information || []);
+    } catch (e) {
+      console.error("문제 조회 실패", e);
+      setPracticeQuestions([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+
+  if (token && noteId) {
+    setAuthToken(token); 
+    fetchPractice();
+  }
+}, [noteId, token]);
+
+
 
   useEffect(() => {
     const fetchData = async () => {
@@ -33,6 +71,7 @@ export default function SummaryPage() {
     };
     fetchData();
   }, [folderId, noteId]);
+
 
   useEffect(() => {
     function updateWidth() {
@@ -54,7 +93,7 @@ export default function SummaryPage() {
         </p>
       </div>
 
-      <div className="flex flex-row w-full pt-12 h-full top-0 items-start ">
+      <div className="flex flex-row w-full pt-12 h-full top-0 items-start">
         <div
           ref={leftAreaRef}
           className="flex-1 flex flex-col justify-center w-full"
@@ -76,18 +115,24 @@ export default function SummaryPage() {
           <button
             className="bg-black-80 text-white px-8 py-6 rounded-lg text-left flex justify-between items-center"
             onClick={() =>
-              router.push(`/notes/${folderId}/${noteId}/create-practice`)
+              router.push(
+                `/notes/${folderId}/${noteId}/${
+                  practiceQuestions.length > 0 ? "result" : "create-practice"
+                }`
+              )
             }
           >
-            복습 퀴즈 생성
+            {practiceQuestions.length > 0 ? "복습 퀴즈 조회" : "복습 퀴즈 생성"}
             <Icon label="arrow_next" className="w-4 h-4" />
           </button>
+
           <button className="bg-black-80 text-white px-8 py-6 rounded-lg text-left flex justify-between items-center">
             하이라이트 영상 제작
             <Icon label="arrow_next" className="w-4 h-4" />
           </button>
         </div>
       </div>
+
       {leftWidth && (
         <div
           className="fixed bottom-0 left-auto flex justify-end py-20 z-50 bg-black-100 bg-opacity-90"

--- a/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
+++ b/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
@@ -24,12 +24,6 @@ export default function SummaryPage() {
   const { data: session, status } = useSession();
   const token = session?.user?.aiTutorToken;
 
-  const setAuthToken = (token: string | null) => {
-    if (token) {
-      localStorage.setItem('aiTutorToken', token);
-    }
-  };
-
   useEffect(() => {
     const fetchPractice = async () => {
       try {
@@ -45,7 +39,6 @@ export default function SummaryPage() {
     };
 
     if (token && noteId) {
-      setAuthToken(token);
       fetchPractice();
     }
   }, [noteId, token]);

--- a/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
+++ b/src/app/(routes)/notes/[folderId]/[noteId]/summary/page.tsx
@@ -1,20 +1,20 @@
-"use client";
+'use client';
 
-import React, { useEffect, useState, useRef } from "react";
-import { useParams, useRouter } from "next/navigation";
-import { fetchSummary } from "@/app/api/summaries/fetchSummary";
-import Icon from "@/app/components/atoms/Icon";
-import Button from "@/app/components/atoms/Button";
-import { PDFDownloadLink } from "@react-pdf/renderer";
-import { SummaryPDFDocument } from "@/app/utils/pdfExportSummary";
-import { getPractice } from "@/app/api/practice/getPractice";
-import { useSession } from "next-auth/react";
+import React, { useEffect, useState, useRef } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { fetchSummary } from '@/app/api/summaries/fetchSummary';
+import Icon from '@/app/components/atoms/Icon';
+import Button from '@/app/components/atoms/Button';
+import { PDFDownloadLink } from '@react-pdf/renderer';
+import { SummaryPDFDocument } from '@/app/utils/pdfExportSummary';
+import { getPractice } from '@/app/api/practice/getPractice';
+import { useSession } from 'next-auth/react';
 
 export default function SummaryPage() {
   const { folderId, noteId } = useParams();
   const router = useRouter();
 
-  const [summary, setSummary] = useState("");
+  const [summary, setSummary] = useState('');
   const [loading, setLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -23,35 +23,32 @@ export default function SummaryPage() {
   const [leftWidth, setLeftWidth] = useState<number | null>(null);
   const { data: session, status } = useSession();
   const token = session?.user?.aiTutorToken;
+
   const setAuthToken = (token: string | null) => {
     if (token) {
-      localStorage.setItem("aiTutorToken", token);
-    }}
-
-
-
-  useEffect(() => {
-  const fetchPractice = async () => {
-    try {
-      setIsLoading(true);
-      const data = await getPractice(Number(noteId));
-      setPracticeQuestions(data?.information || []);
-    } catch (e) {
-      console.error("문제 조회 실패", e);
-      setPracticeQuestions([]);
-    } finally {
-      setIsLoading(false);
+      localStorage.setItem('aiTutorToken', token);
     }
   };
 
+  useEffect(() => {
+    const fetchPractice = async () => {
+      try {
+        setIsLoading(true);
+        const data = await getPractice(Number(noteId));
+        setPracticeQuestions(data?.information || []);
+      } catch (e) {
+        console.error('문제 조회 실패', e);
+        setPracticeQuestions([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
 
-  if (token && noteId) {
-    setAuthToken(token); 
-    fetchPractice();
-  }
-}, [noteId, token]);
-
-
+    if (token && noteId) {
+      setAuthToken(token);
+      fetchPractice();
+    }
+  }, [noteId, token]);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -62,16 +59,15 @@ export default function SummaryPage() {
           folderId: Number(folderId),
           noteId: Number(noteId),
         });
-        setSummary(data.information.summary || "");
+        setSummary(data.information.summary || '');
       } catch (error) {
-        setSummary("요약문을 불러오지 못했습니다.");
+        setSummary('요약문을 불러오지 못했습니다.');
       } finally {
         setLoading(false);
       }
     };
     fetchData();
   }, [folderId, noteId]);
-
 
   useEffect(() => {
     function updateWidth() {
@@ -80,8 +76,8 @@ export default function SummaryPage() {
       }
     }
     updateWidth();
-    window.addEventListener("resize", updateWidth);
-    return () => window.removeEventListener("resize", updateWidth);
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
   }, []);
 
   return (
@@ -103,12 +99,12 @@ export default function SummaryPage() {
             className="w-full h-64 p-2 px-3 bg-black-80 placeholder:text-black-70 text-white rounded-lg resize-none outline-none"
             maxLength={300}
             placeholder="강의에서 강조하고 싶은 내용, 어투와 문장 등을 작성하세요."
-            value={loading ? "불러오는 중..." : summary}
+            value={loading ? '불러오는 중...' : summary}
             readOnly
           />
         </div>
 
-        <div className="w-px bg-black-70 mx-8" style={{ minHeight: "500px" }} />
+        <div className="w-px bg-black-70 mx-8" style={{ minHeight: '500px' }} />
 
         <div className="flex flex-col gap-3.5 justify-center min-w-[220px]">
           <p className="text-white font-semibold">복습 자료 만들기</p>
@@ -117,12 +113,12 @@ export default function SummaryPage() {
             onClick={() =>
               router.push(
                 `/notes/${folderId}/${noteId}/${
-                  practiceQuestions.length > 0 ? "result" : "create-practice"
+                  practiceQuestions.length > 0 ? 'result' : 'create-practice'
                 }`
               )
             }
           >
-            {practiceQuestions.length > 0 ? "복습 퀴즈 조회" : "복습 퀴즈 생성"}
+            {practiceQuestions.length > 0 ? '복습 퀴즈 조회' : '복습 퀴즈 생성'}
             <Icon label="arrow_next" className="w-4 h-4" />
           </button>
 

--- a/src/app/api/folders/index.ts
+++ b/src/app/api/folders/index.ts
@@ -52,3 +52,12 @@ export const getFolders = async () => {
   const response = await apiClient.get(`${baseURL}/api/v1/folders`);
   return response.data.information;
 };
+
+export const getFoldersContent = async() => {
+  const authHeader = apiClient.defaults.headers.common["Authorization"];
+  if (!authHeader) {
+    return [];
+  }
+  const response = await apiClient.get(`${baseURL}/api/v1/folders/notes`);
+  return response.data.information;
+}

--- a/src/app/components/organisms/NoteList.tsx
+++ b/src/app/components/organisms/NoteList.tsx
@@ -22,7 +22,7 @@ const NoteList: React.FC<NoteListProps> = ({
   const [selectedNoteId, setSelectedNoteId] = useState<number | null>(null);
 
   const handleNoteClick = (noteId: number) => {
-    router.push(`/notes/${folderId}/${noteId}/result`);
+    router.push(`/notes/${folderId}/${noteId}/summary`);
   };
 
   const handleDeleteNote = (id: number) => {

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -3,14 +3,25 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import Icon from "../atoms/Icon";
-import { useFetchFolders } from "@/app/hooks/folder/useFetchFolders";
 import { setAuthToken } from "@/app/utils/api";
 import { useSession } from "next-auth/react";
+import useFetchFolderContent from "@/app/hooks/folder/useFetchFolderContent";
+import { useRouter } from "next/navigation";
+
+interface Folder {
+  folderId: number;
+  folderName: string;
+  notesInFolderRes?: {
+    noteId: number;
+    noteName: string;
+  }[];
+}
 
 const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
+  const router = useRouter();
 
   useEffect(() => {
     if (token) {
@@ -19,65 +30,98 @@ const Sidebar: React.FC = () => {
     }
   }, [token]);
 
-  const { data: folders = [], isLoading, error } = useFetchFolders();
+  const { data, isLoading, error } = useFetchFolderContent(token ?? undefined);
+  const folders = data?.folderNoteDetailList || [];
+  const [isNoteOpen, setIsNoteOpen] = useState<{ [noteId: number]: boolean }>({});
+
+  const toggleNote = (noteId: number) => {
+    setIsNoteOpen((prev) => ({
+      ...prev,
+      [noteId]: !prev[noteId],
+    }));
+  };
 
   const [showSections, setShowSections] = useState(false);
   const toggleSections = () => setShowSections(!showSections);
 
   return (
-    <div className="min-w-[220px] h-screen justify-between flex flex-col z-20 bg-black px-2">
+    <div className="min-w-[220px] h-screen justify-between flex flex-col z-20 bg-black">
       <div className="flex flex-col h-full rounded-lg bg-black">
+     
         <Link href="/home">
           <div className="flex items-center justify-center px-2">
             <Icon label="icon" className="w-[110px] h-[70px] m-auto" />
           </div>
         </Link>
+
         <div>
+      
           <div className="hover:bg-black-70 hover:rounded-lg cursor-pointer transition-colors duration-200 rounded-lg">
             <Link href="/home">
               <div className="px-8 py-2 flex flex-row text-center gap-3">
-                <Icon
-                  label="ic_side_home"
-                  className="w-[20px] h-[20px] my-auto"
-                />
+                <Icon label="ic_side_home" className="w-[20px] h-[20px] my-auto" />
                 <p className="text-white">홈</p>
               </div>
             </Link>
           </div>
+
           <div className="flex flex-col">
             <div
               className="px-8 py-2 flex flex-row text-center gap-3 cursor-pointer hover:bg-[#3c3c3c] hover:rounded-md rounded-md transition-colors duration-200"
               onClick={toggleSections}
             >
-              <Icon
-                label="ic_side_folder"
-                className="w-[20px] h-[20px] m-auto"
-              />
+              <Icon label="ic_side_folder" className="w-[20px] h-[20px] m-auto" />
               <p className="text-white mr-8 flex-shrink-0">강의 과목</p>
               <Icon
                 label="arrow_sidebar"
-                className={`h-[16px] w-[16px] my-auto invert transition-transform ${
-                  showSections ? "rotate-90" : ""
+                className={`h-[16px] w-[16px] my-auto invert transition-transform duration-300 ${
+                  showSections ? "-rotate-90" : "rotate-90"
                 }`}
               />
             </div>
+
             {showSections &&
-              folders.map((folder) => (
-                <Link key={folder.folderId} href={`/notes/${folder.folderId}`}>
-                  <div className="px-8 py-2 flex flex-row text-center gap-3 hover:bg-[#3c3c3c] hover:rounded-md cursor-pointer transition-colors duration-200">
-                    <Icon
-                      label="ic_side_folder"
-                      className="w-[20px] h-[20px] my-auto"
-                    />
-                    <p className="text-sm text-white flex-shrink-0">
-                      {folder.folderName}
-                    </p>
+              folders.map((folder: Folder) => (
+                <div key={folder.folderId}>
+                  <div
+                    onClick={() => toggleNote(folder.folderId)}
+                    className="px-8 py-2 flex w-full justify-between flex-row text-center gap-3 hover:bg-[#3c3c3c] rounded-md cursor-pointer transition-colors duration-200"
+                  >
+                    <div className="flex flex-row gap-3">
+                      <Icon label="ic_side_folder" className="w-[20px] h-[20px] my-auto" />
+                      <p className="text-base text-white flex-shrink-0">{folder.folderName}</p>
+                    </div>
+
+                    {(folder.notesInFolderRes?.length ?? 0) > 0 && (
+                      <Icon
+                        label="arrow_sidebar"
+                        className={`h-[16px] w-[16px] my-auto invert transition-transform duration-300 ${
+                          isNoteOpen[folder.folderId] ? "-rotate-90" : "rotate-90"
+                        }`}
+                      />
+                    )}
                   </div>
-                </Link>
+
+                  {(folder.notesInFolderRes?.length ?? 0) > 0 && isNoteOpen[folder.folderId] && (
+                    <div className="space-y-1">
+                      {folder.notesInFolderRes?.map((note) => (
+                        <Link
+                          key={note.noteId}
+                          href={`/notes/${folder.folderId}/${note.noteId}`}
+                        >
+                          <div className="w-full my-0.5 pl-16 text-base hover:bg-black-90 bg-black-80 text-white py-2 hover:text-white cursor-pointer">
+                            {note.noteName}
+                          </div>
+                        </Link>
+                      ))}
+                    </div>
+                  )}
+                </div>
               ))}
           </div>
         </div>
       </div>
+
       <div className="pb-8">
         <div className="hover:bg-black-80 hover:rounded-md cursor-pointer transition-colors duration-200 rounded-md">
           <div className="flex flex-row px-[35px] py-2 gap-3">

--- a/src/app/hooks/folder/useFetchFolderContent.ts
+++ b/src/app/hooks/folder/useFetchFolderContent.ts
@@ -1,0 +1,13 @@
+import React from 'react'
+import { useQuery } from "@tanstack/react-query";
+import { getFoldersContent } from "@/app/api/folders";
+
+export default function useFetchFolderContent(token: string | undefined, enabled = true) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["folders", token],
+    queryFn: getFoldersContent,
+    enabled: !!token && enabled,
+  });
+
+  return { data, isLoading, error };
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #77 

## 🌏 Summary
- [x] 폴더 클릭 시 노트 조회 및 화살표 변경
- [x] 폴더 다시 클릭 시 닫힘 처리
- [x] 노트 클릭 시 페이지 진입 및 색상 표시
- [x] 노트 없는 폴더는 비활성 처리
- [x] 홈화면일 때 SNB '홈' 색상 표시
- [x] 노트 진입 시 요약문 먼저 표시 → 복습 퀴즈 흐름 연결

## 📸 스크린샷

## 🤔 고민했던 내용
- 현재 교수명과 과목명은 전역 상태로 관리되고 있는데, 폴더(과목)를 여러 개 클릭하면 마지막으로 클릭한 폴더의 정보만 유지됩니다.
- 폴더마다 교수명이 다를 수 있기 때문에, 정보가 덮어씌워지는 문제가 발생합니다.
-> 폴더 ID와 함께 professor, folderName을 개별 저장하거나, 서버에서 교수명도 함께 내려받는 구조로 변경하는 것이 더 적절하다고 생각하는데, 어떻게 생각하시나요



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar now displays folders with expandable lists of notes, allowing users to view and navigate to notes within each folder.
  * Sidebar highlights the active folder and note based on the current route for easier navigation.
  * Added integration for practice questions in the note summary page, with dynamic button labeling and navigation depending on question availability.
  * Introduced a new folder content fetching hook to support detailed folder and note data retrieval.

* **Bug Fixes**
  * Improved navigation so clicking a note leads to its summary page instead of the result page.

* **Refactor**
  * Sidebar refactored for smoother expand/collapse transitions and improved route-based styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->