### PR TITLE
<Refactor> QA전, 여러 디자인 및 UX 개선사항 반영

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@netlify/plugin-nextjs": "^5.8.1",
-        "@react-pdf/renderer": "^4.1.6",
+        "@react-pdf/renderer": "^4.3.0",
         "@tanstack/react-query": "^5.67.2",
         "axios": "^1.7.7",
         "js-cookie": "^3.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "react-hot-toast": "^2.5.2",
         "react-slick": "^0.30.3",
         "slick-carousel": "^1.8.1",
-        "zustand": "^5.0.0-rc.2"
+        "zustand": "^5.0.5"
       },
       "devDependencies": {
         "@types/node": "^20",
@@ -7238,9 +7238,9 @@
       "license": "MIT"
     },
     "node_modules/zustand": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
-      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.5.tgz",
+      "integrity": "sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-hot-toast": "^2.5.2",
     "react-slick": "^0.30.3",
     "slick-carousel": "^1.8.1",
-    "zustand": "^5.0.0-rc.2"
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@netlify/plugin-nextjs": "^5.8.1",
-    "@react-pdf/renderer": "^4.1.6",
+    "@react-pdf/renderer": "^4.3.0",
     "@tanstack/react-query": "^5.67.2",
     "axios": "^1.7.7",
     "js-cookie": "^3.0.5",

--- a/src/app/(routes)/home/page.tsx
+++ b/src/app/(routes)/home/page.tsx
@@ -27,6 +27,7 @@ import toast from 'react-hot-toast';
 
 const HomePage = () => {
   const { data: session, status } = useSession();
+
   const token = session?.user?.aiTutorToken;
   const { data: folders = [] } = useFetchFolders({
     enabled: status === 'authenticated' && !!token,
@@ -34,7 +35,7 @@ const HomePage = () => {
   const createFolder = useCreateFolder();
   const updateFolder = useUpdateFolder();
   const deleteFolder = useDeleteFolder();
-  const { open } = useOnboardingstore();
+  const { isOpen, open } = useOnboardingstore();
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [showModify, setShowModify] = useState<{ [key: string]: boolean }>({});
   const [showModal, setShowModal] = useState(false);
@@ -122,7 +123,7 @@ const HomePage = () => {
 
         <div className="bg-black-80 rounded-lg rounded-b-none mx-4 h-full">
           <div className="flex text-center">
-            {showOnboarding && <OnBoardingModal></OnBoardingModal>}
+            {isOpen && <OnBoardingModal></OnBoardingModal>}
           </div>
           {folders.length === 0 ? (
             <div className="flex flex-col justify-center items-center h-full text-center text-white">

--- a/src/app/(routes)/home/page.tsx
+++ b/src/app/(routes)/home/page.tsx
@@ -1,50 +1,55 @@
-"use client";
-import React, { useState } from "react";
-import Button from "@/app/components/atoms/Button";
+'use client';
+import React, { useEffect, useState } from 'react';
+import Button from '@/app/components/atoms/Button';
 import {
   SectionFolder,
   SectionModal,
   SectionModify,
-} from "@/app/components/molecules/Modal";
-import { useFetchFolders } from "@/app/hooks/folder/useFetchFolders";
-import { useCreateFolder } from "@/app/hooks/folder/useCreateFolder";
-import { useUpdateFolder } from "@/app/hooks/folder/useUpdateFolder";
-import { useDeleteFolder } from "@/app/hooks/folder/useDeleteFolder";
-import { useSession } from "next-auth/react";
-import Image from "next/image";
-import speach_bubble from "../../../../public/speech_bubble.svg";
-import { Folder } from "@/app/types/folder";
+} from '@/app/components/molecules/Modal';
+import {
+  getIsFirstTimeUser,
+  setIsFirstTimeUser,
+} from '@/app/utils/localstorage';
+import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
+import { useCreateFolder } from '@/app/hooks/folder/useCreateFolder';
+import { useUpdateFolder } from '@/app/hooks/folder/useUpdateFolder';
+import { useDeleteFolder } from '@/app/hooks/folder/useDeleteFolder';
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
+import { useSession } from 'next-auth/react';
+import Image from 'next/image';
+import speach_bubble from '../../../../public/speech_bubble.svg';
+import { Folder } from '@/app/types/folder';
 
-import { useOnboarding } from "@/app/hooks/useOnboarding";
+import { useOnboarding } from '@/app/hooks/useOnboarding';
 
-import OnBoardingModal from "@/app/components/molecules/OnBoardingModal";
-import toast from "react-hot-toast";
+import OnBoardingModal from '@/app/components/molecules/OnBoardingModal';
+import toast from 'react-hot-toast';
 
 const HomePage = () => {
   const { data: session, status } = useSession();
   const token = session?.user?.aiTutorToken;
   const { data: folders = [] } = useFetchFolders({
-    enabled: status === "authenticated" && !!token,
+    enabled: status === 'authenticated' && !!token,
   });
   const createFolder = useCreateFolder();
   const updateFolder = useUpdateFolder();
   const deleteFolder = useDeleteFolder();
-
+  const { open } = useOnboardingstore();
   const [selectedFolder, setSelectedFolder] = useState<Folder | null>(null);
   const [showModify, setShowModify] = useState<{ [key: string]: boolean }>({});
   const [showModal, setShowModal] = useState(false);
-  const [subject, setSubject] = useState("");
-  const [professor, setProfessor] = useState("");
+  const [subject, setSubject] = useState('');
+  const [professor, setProfessor] = useState('');
   const [isEditMode, setIsEditMode] = useState(false);
 
   const handleCreateFolder = async (): Promise<boolean> => {
     if (!subject) {
-      toast.error("과목명을 입력해주세요.");
+      toast.error('과목명을 입력해주세요.');
       return false;
     }
 
     if (!professor) {
-      toast.error("교수명을 입력해주세요.");
+      toast.error('교수명을 입력해주세요.');
       return false;
     }
 
@@ -52,8 +57,8 @@ const HomePage = () => {
       folderName: subject,
       professorName: professor,
     });
-    setSubject("");
-    setProfessor("");
+    setSubject('');
+    setProfessor('');
     return true;
   };
 
@@ -76,6 +81,13 @@ const HomePage = () => {
     setSelectedFolder(null);
   };
   const { showOnboarding, closeOnboarding } = useOnboarding();
+
+  useEffect(() => {
+    if (getIsFirstTimeUser()) {
+      open();
+      setIsFirstTimeUser(false);
+    }
+  }, []);
 
   return (
     <div className="flex flex-col justify-between h-full w-full">
@@ -100,8 +112,8 @@ const HomePage = () => {
               variant="create"
               onClick={() => {
                 setIsEditMode(false);
-                setSubject("");
-                setProfessor("");
+                setSubject('');
+                setProfessor('');
                 setShowModal(true);
               }}
             />
@@ -110,9 +122,7 @@ const HomePage = () => {
 
         <div className="bg-black-80 rounded-lg rounded-b-none mx-4 h-full">
           <div className="flex text-center">
-            {showOnboarding && (
-              <OnBoardingModal onClose={closeOnboarding}></OnBoardingModal>
-            )}
+            {showOnboarding && <OnBoardingModal></OnBoardingModal>}
           </div>
           {folders.length === 0 ? (
             <div className="flex flex-col justify-center items-center h-full text-center text-white">

--- a/src/app/(routes)/layout.tsx
+++ b/src/app/(routes)/layout.tsx
@@ -1,25 +1,26 @@
-"use client";
+'use client';
 
-import Sidebar from "@/app/components/utils/Sidebar";
-import { PracticeProvider } from "@/app/context/PracticeContext";
-import { usePathname } from "next/navigation";
-import "@/app/globals.css";
-import { Toaster } from "react-hot-toast";
-import useAuthInterceptor from "../hooks/auth/useAuthInterceptor";
-
+import Sidebar from '@/app/components/utils/Sidebar';
+import { PracticeProvider } from '@/app/context/PracticeContext';
+import { usePathname } from 'next/navigation';
+import '@/app/globals.css';
+import { Toaster } from 'react-hot-toast';
+import useAuthInterceptor from '../hooks/auth/useAuthInterceptor';
+import OnBoardingModal from '../components/molecules/OnBoardingModal';
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   const pathname = usePathname();
-  const isLoginPage = pathname.startsWith("/login");
+  const isLoginPage = pathname.startsWith('/login');
 
   useAuthInterceptor();
 
   return (
     <div>
       <PracticeProvider>
+        <OnBoardingModal />
         <Toaster />
         <div className="flex bg-black">
           {!isLoginPage && <Sidebar />}

--- a/src/app/components/molecules/Modal.tsx
+++ b/src/app/components/molecules/Modal.tsx
@@ -1,18 +1,18 @@
-"use client";
+'use client';
 
-import React, { useEffect, useState } from "react";
-import Image from "next/image";
-import { FolderListData } from "@/app/types/folder";
-import Icon from "../atoms/Icon";
-import { useRouter } from "next/navigation";
-import delete_bin_red from "../../../../public/delete_bin_red.svg";
-import note from "../../../../public/note.svg";
-import { toast } from "react-hot-toast";
+import React, { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { FolderListData } from '@/app/types/folder';
+import Icon from '../atoms/Icon';
+import { useRouter } from 'next/navigation';
+import delete_bin_red from '../../../../public/delete_bin_red.svg';
+import note from '../../../../public/note.svg';
+import { toast } from 'react-hot-toast';
 
-import folder from "../../../../public/folder.svg";
-import folderOpened from "../../../../public/folder_opened.svg";
-import filledFolder from "../.././../../public/filled_folder.svg";
-import filledFolderOpened from "../../../../public/filled_folder_opened.svg";
+import folder from '../../../../public/folder.svg';
+import folderOpened from '../../../../public/folder_opened.svg';
+import filledFolder from '../.././../../public/filled_folder.svg';
+import filledFolderOpened from '../../../../public/filled_folder_opened.svg';
 
 export const SectionFolder: React.FC<{
   section: FolderListData;
@@ -177,7 +177,7 @@ export const SectionModal: React.FC<{
                 className="bg-primary rounded-lg text-white px-8 py-2"
                 disabled={isSaving}
               >
-                {isSaving ? "저장 중..." : "저장"}
+                {isSaving ? '저장 중...' : '저장'}
               </button>
             </div>
           </div>
@@ -200,10 +200,10 @@ export const DeleteModal: React.FC<{
 
     try {
       await onDelete();
-      toast.success("노트가 성공적으로 삭제되었습니다.");
+      // toast.success("노트가 성공적으로 삭제되었습니다.");
       onClose();
     } catch (error) {
-      toast.error("노트 삭제 중 오류가 발생했습니다.");
+      toast.error('노트 삭제 중 오류가 발생했습니다.');
     } finally {
       setIsSaving(false);
     }
@@ -231,7 +231,7 @@ export const DeleteModal: React.FC<{
                 className="bg-red-600 rounded-lg text-white px-8 py-2"
                 disabled={isSaving}
               >
-                {isSaving ? "삭제 중..." : "삭제"}
+                {isSaving ? '삭제 중...' : '삭제'}
               </button>
             </div>
           </div>

--- a/src/app/components/molecules/OnBoardingModal.tsx
+++ b/src/app/components/molecules/OnBoardingModal.tsx
@@ -1,24 +1,23 @@
 import React, { useState } from 'react';
-
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
 import Image from 'next/image';
 import OnBoardingCarousel from './OnBoardingCarousel';
 import { slides } from '@/app/constants/OnBoardingModalImageList';
 
-interface OnBoardingModalProps {
-  onClose: () => void;
-}
-
-const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
+const OnBoardingModal: React.FC = () => {
   const [slideIndex, setSlideIndex] = useState(0);
 
   const handleSlideClicked = (index: number) => {
     setSlideIndex(index);
   };
 
+  const { isOpen, close } = useOnboardingstore();
+
+  if (!isOpen) return null;
   return (
     <div
       className="fixed flex flex-col z-50 inset-0 items-center justify-center bg-black bg-opacity-50 backdrop-blur-md"
-      onClick={onClose}
+      onClick={close}
     >
       <div
         onClick={(e) => e.stopPropagation()}
@@ -41,7 +40,7 @@ const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
         ></OnBoardingCarousel>{' '}
         <button
           className="absolute top-4 right-1 bg-transparent text-white px-3 py-1 rounded-md"
-          onClick={onClose}
+          onClick={close}
         >
           ✕
         </button>

--- a/src/app/components/molecules/OnBoardingModal.tsx
+++ b/src/app/components/molecules/OnBoardingModal.tsx
@@ -6,11 +6,9 @@ import { slides } from '@/app/constants/OnBoardingModalImageList';
 
 interface OnBoardingModalProps {
   onClose: () => void;
-  //필요 props 추가할거 있으면 해야할듯 합니다.
 }
 
 const OnBoardingModal: React.FC<OnBoardingModalProps> = ({ onClose }) => {
-  //carousel IMG Array
   const [slideIndex, setSlideIndex] = useState(0);
 
   const handleSlideClicked = (index: number) => {

--- a/src/app/components/molecules/OnBoardingModal.tsx
+++ b/src/app/components/molecules/OnBoardingModal.tsx
@@ -21,7 +21,7 @@ const OnBoardingModal: React.FC = () => {
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="relative w-[800px] h-[200px] max-w-full bg-transparent -translate-y-20
+        className="relative w-[800px] max-w-full bg-transparent items-center justify-center
       "
       >
         <div className="relative w-full">

--- a/src/app/components/organisms/NewPracticeForm.tsx
+++ b/src/app/components/organisms/NewPracticeForm.tsx
@@ -45,12 +45,31 @@ const NewPracticeForm: React.FC = () => {
   }, [oxRef, shortRef]);
 
   const handleCountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newSize = Number(event.target.value);
-    if (isNaN(newSize) || newSize < 1) {
-      toast.error('1 이상의 숫자를 입력해주세요.');
+    const value = event.target.value.trim();
+
+    const newSize = Number(value);
+    if (!/^\d+$/.test(value) && newSize.toString().length > 1) {
+      toast.dismiss();
+      toast.error('숫자만 입력해주세요.', { id: 'count-error' });
+      return;
+    }
+
+    if (newSize < 1 && newSize.toString().length > 1) {
+      toast.dismiss();
+      toast.error('1 이상의 숫자를 입력해주세요.', { id: 'count-error' });
       setPracticeSize(0);
       return;
     }
+
+    if (newSize > 20) {
+      toast.dismiss();
+      toast.error('20 이하로 입력해주세요.', { id: 'count-error' });
+
+      setPracticeSize(20);
+      return;
+    }
+
+    toast.dismiss();
     setPracticeSize(newSize);
   };
 

--- a/src/app/components/organisms/NewPracticeForm.tsx
+++ b/src/app/components/organisms/NewPracticeForm.tsx
@@ -1,29 +1,30 @@
-import React, { useEffect, useRef, useState } from "react";
-import Button from "@/app/components/atoms/Button";
-import CountInput from "@/app/components/atoms/CountInput";
-import Popover from "@/app/components/molecules/PopOver";
-import { usePracticeContext } from "@/app/context/PracticeContext";
-import ToggleSelect from "../atoms/ToggleSelect";
+import React, { useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import Button from '@/app/components/atoms/Button';
+import CountInput from '@/app/components/atoms/CountInput';
+import Popover from '@/app/components/molecules/PopOver';
+import { usePracticeContext } from '@/app/context/PracticeContext';
+import ToggleSelect from '../atoms/ToggleSelect';
 
 const NewPracticeForm: React.FC = () => {
   const { practiceSize, setPracticeSize, type, setType } = usePracticeContext();
-  const [countOption, setCountOption] = useState<"AI" | "manual">("AI");
-  const [showPopover, setShowPopover] = useState<"OX" | "SHORT" | null>(null);
+  const [countOption, setCountOption] = useState<'AI' | 'manual'>('AI');
+  const [showPopover, setShowPopover] = useState<'OX' | 'SHORT' | null>(null);
   const oxRef = useRef<HTMLDivElement>(null);
   const shortRef = useRef<HTMLDivElement>(null);
   const [oxPopoverPosition, setOXPopoverPosition] = useState<{
     top: string;
     left: string;
   }>({
-    top: "0px",
-    left: "0px",
+    top: '0px',
+    left: '0px',
   });
   const [shortPopoverPosition, setShortPopoverPosition] = useState<{
     top: string;
     left: string;
   }>({
-    top: "0px",
-    left: "0px",
+    top: '0px',
+    left: '0px',
   });
 
   useEffect(() => {
@@ -45,24 +46,29 @@ const NewPracticeForm: React.FC = () => {
 
   const handleCountChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const newSize = Number(event.target.value);
-    setPracticeSize(isNaN(newSize) ? 0 : newSize);
+    if (isNaN(newSize) || newSize < 1) {
+      toast.error('1 이상의 숫자를 입력해주세요.');
+      setPracticeSize(0);
+      return;
+    }
+    setPracticeSize(newSize);
   };
 
-  const toggleType = (selectedType: "OX" | "SHORT") => {
-    if (type === "") {
+  const toggleType = (selectedType: 'OX' | 'SHORT') => {
+    if (type === '') {
       setType(selectedType);
-    } else if (type === "OX" && selectedType === "OX") {
-      setType("");
-    } else if (type === "SHORT" && selectedType === "SHORT") {
-      setType("");
-    } else if (type === "OX" && selectedType === "SHORT") {
-      setType("BOTH");
-    } else if (type === "SHORT" && selectedType === "OX") {
-      setType("BOTH");
-    } else if (type === "BOTH" && selectedType === "OX") {
-      setType("SHORT");
-    } else if (type === "BOTH" && selectedType === "SHORT") {
-      setType("OX");
+    } else if (type === 'OX' && selectedType === 'OX') {
+      setType('');
+    } else if (type === 'SHORT' && selectedType === 'SHORT') {
+      setType('');
+    } else if (type === 'OX' && selectedType === 'SHORT') {
+      setType('BOTH');
+    } else if (type === 'SHORT' && selectedType === 'OX') {
+      setType('BOTH');
+    } else if (type === 'BOTH' && selectedType === 'OX') {
+      setType('SHORT');
+    } else if (type === 'BOTH' && selectedType === 'SHORT') {
+      setType('OX');
     }
   };
 
@@ -74,21 +80,21 @@ const NewPracticeForm: React.FC = () => {
         </span>
         <div className="flex flex-row">
           <ToggleSelect
-            items={["AI 추천", "직접 입력"]}
+            items={['AI 추천', '직접 입력']}
             onClick={(selectedItem) => {
-              setCountOption(selectedItem === "AI 추천" ? "AI" : "manual");
-              if (selectedItem === "AI 추천") {
+              setCountOption(selectedItem === 'AI 추천' ? 'AI' : 'manual');
+              if (selectedItem === 'AI 추천') {
                 setPracticeSize(0);
               }
             }}
-            isSelected={countOption === "manual"}
+            isSelected={countOption === 'manual'}
           />
 
-          {countOption === "manual" && (
+          {countOption === 'manual' && (
             <CountInput
               name="count"
               defaultValue={
-                practiceSize !== null ? practiceSize.toString() : ""
+                practiceSize !== null ? practiceSize.toString() : ''
               }
               onChange={handleCountChange}
               placeholder="문제 개수를 입력하세요"
@@ -102,31 +108,31 @@ const NewPracticeForm: React.FC = () => {
         <div className="flex flex-row gap-2">
           <div
             ref={oxRef}
-            onMouseEnter={() => setShowPopover("OX")}
+            onMouseEnter={() => setShowPopover('OX')}
             onMouseLeave={() => setShowPopover(null)}
           >
             <Button
               label="OX 퀴즈"
               variant="select"
-              isSelected={type === "OX" || type === "BOTH"}
-              onClick={() => toggleType("OX")}
+              isSelected={type === 'OX' || type === 'BOTH'}
+              onClick={() => toggleType('OX')}
             />
-            {showPopover === "OX" && (
+            {showPopover === 'OX' && (
               <Popover type="OX" position={oxPopoverPosition} />
             )}
           </div>
           <div
             ref={shortRef}
-            onMouseEnter={() => setShowPopover("SHORT")}
+            onMouseEnter={() => setShowPopover('SHORT')}
             onMouseLeave={() => setShowPopover(null)}
           >
             <Button
               label="단답형"
               variant="select"
-              isSelected={type === "SHORT" || type === "BOTH"}
-              onClick={() => toggleType("SHORT")}
+              isSelected={type === 'SHORT' || type === 'BOTH'}
+              onClick={() => toggleType('SHORT')}
             />
-            {showPopover === "SHORT" && (
+            {showPopover === 'SHORT' && (
               <Popover type="단답형" position={shortPopoverPosition} />
             )}
           </div>

--- a/src/app/components/organisms/SummaryText.tsx
+++ b/src/app/components/organisms/SummaryText.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { baseURL } from "@/app/api/index";
-import { usePracticeContext } from "@/app/context/PracticeContext";
-import axios from "axios";
+import React from 'react';
+import { baseURL } from '@/app/api/index';
+import { usePracticeContext } from '@/app/context/PracticeContext';
+import axios from 'axios';
+import { parseMarkdown } from '@/app/utils/parseMarkdown';
 import {
   Document,
   Font,
@@ -10,23 +11,23 @@ import {
   StyleSheet,
   Text,
   View,
-} from "@react-pdf/renderer";
-import Button from "../atoms/Button";
+} from '@react-pdf/renderer';
+import Button from '../atoms/Button';
 
 Font.register({
-  family: "SpoqaHanSans",
-  src: "https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@01ff0283e4f36e159ffbf744b36e16ef742da6d8/Subset/SpoqaHanSans/SpoqaHanSansLight.ttf",
+  family: 'SpoqaHanSans',
+  src: 'https://cdn.jsdelivr.net/gh/spoqa/spoqa-han-sans@01ff0283e4f36e159ffbf744b36e16ef742da6d8/Subset/SpoqaHanSans/SpoqaHanSansLight.ttf',
 });
 
 const styles = StyleSheet.create({
   page: {
-    fontFamily: "SpoqaHanSans",
+    fontFamily: 'SpoqaHanSans',
     padding: 20,
   },
   title: {
     fontSize: 18,
     marginBottom: 10,
-    textAlign: "center",
+    textAlign: 'center',
   },
   content: {
     fontSize: 12,
@@ -38,7 +39,8 @@ const PDFDocument = ({ summary }: { summary: string }) => (
   <Document>
     <Page size="A4" style={styles.page}>
       <Text style={styles.title}>Summary Document</Text>
-      <Text style={styles.content}>{summary}</Text>
+
+      <View>{parseMarkdown(summary)}</View>
     </Page>
   </Document>
 );
@@ -58,7 +60,7 @@ const SummaryText: React.FC<SummaryTextProps> = ({ folderId, noteId }) => {
       );
       setSummary(response.data.information.summary);
     } catch (error) {
-      console.error("Failed to fetch summary:", error);
+      console.error('Failed to fetch summary:', error);
     }
   };
 

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useOnboarding } from '@/app/hooks/useOnboarding';
+import { useOnboardingstore } from '@/app/store/useOnboardingStore';
 import Link from 'next/link';
 import Icon from '../atoms/Icon';
 import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
@@ -12,7 +12,7 @@ const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
-  const { showOnboarding, closeOnboarding } = useOnboarding();
+  const { isOpen, close, open } = useOnboardingstore();
 
   useEffect(() => {
     if (token) {
@@ -22,7 +22,7 @@ const Sidebar: React.FC = () => {
   }, [token]);
 
   const handleGuideClick = () => {
-    //클릭 누르면 글로벌 상태 변경
+    open();
   };
 
   const { data: folders = [], isLoading, error } = useFetchFolders();
@@ -86,7 +86,10 @@ const Sidebar: React.FC = () => {
       </div>
       <div className="pb-8">
         <div className="hover:bg-black-80 hover:rounded-md cursor-pointer transition-colors duration-200 rounded-md">
-          <div className="flex flex-row px-[35px] py-2 gap-3">
+          <div
+            onClick={handleGuideClick}
+            className="flex flex-row px-[35px] py-2 gap-3"
+          >
             <Icon label="guide" className="w-[20px] h-[20px] my-auto" />
             <p className="text-white">가이드보기</p>
           </div>

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -1,16 +1,18 @@
-"use client";
+'use client';
 
-import { useEffect, useState } from "react";
-import Link from "next/link";
-import Icon from "../atoms/Icon";
-import { useFetchFolders } from "@/app/hooks/folder/useFetchFolders";
-import { setAuthToken } from "@/app/utils/api";
-import { useSession } from "next-auth/react";
+import { useEffect, useState } from 'react';
+import { useOnboarding } from '@/app/hooks/useOnboarding';
+import Link from 'next/link';
+import Icon from '../atoms/Icon';
+import { useFetchFolders } from '@/app/hooks/folder/useFetchFolders';
+import { setAuthToken } from '@/app/utils/api';
+import { useSession } from 'next-auth/react';
 
 const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
+  const { showOnboarding, closeOnboarding } = useOnboarding();
 
   useEffect(() => {
     if (token) {
@@ -18,6 +20,10 @@ const Sidebar: React.FC = () => {
       setIsAuthSet(true);
     }
   }, [token]);
+
+  const handleGuideClick = () => {
+    //클릭 누르면 글로벌 상태 변경
+  };
 
   const { data: folders = [], isLoading, error } = useFetchFolders();
 
@@ -57,7 +63,7 @@ const Sidebar: React.FC = () => {
               <Icon
                 label="arrow_sidebar"
                 className={`h-[16px] w-[16px] my-auto invert transition-transform ${
-                  showSections ? "rotate-90" : ""
+                  showSections ? 'rotate-90' : ''
                 }`}
               />
             </div>

--- a/src/app/components/utils/Sidebar.tsx
+++ b/src/app/components/utils/Sidebar.tsx
@@ -12,7 +12,7 @@ const Sidebar: React.FC = () => {
   const { data: session } = useSession();
   const token = session?.user?.aiTutorToken;
   const [isAuthSet, setIsAuthSet] = useState(false);
-  const { isOpen, close, open } = useOnboardingstore();
+  const { open } = useOnboardingstore();
 
   useEffect(() => {
     if (token) {
@@ -22,6 +22,8 @@ const Sidebar: React.FC = () => {
   }, [token]);
 
   const handleGuideClick = () => {
+    console.log('클릭');
+
     open();
   };
 
@@ -87,7 +89,9 @@ const Sidebar: React.FC = () => {
       <div className="pb-8">
         <div className="hover:bg-black-80 hover:rounded-md cursor-pointer transition-colors duration-200 rounded-md">
           <div
-            onClick={handleGuideClick}
+            onClick={() => {
+              handleGuideClick();
+            }}
             className="flex flex-row px-[35px] py-2 gap-3"
           >
             <Icon label="guide" className="w-[20px] h-[20px] my-auto" />

--- a/src/app/store/useOnboardingStore.ts
+++ b/src/app/store/useOnboardingStore.ts
@@ -1,0 +1,13 @@
+import { create } from 'zustand';
+
+interface OnboardingStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useOnboardingstore = create<OnboardingStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));

--- a/src/app/utils/parseMarkdown.tsx
+++ b/src/app/utils/parseMarkdown.tsx
@@ -1,0 +1,53 @@
+import { Text } from '@react-pdf/renderer';
+
+export const parseMarkdown = (md: string) => {
+  const lines = md.split('\n');
+
+  return lines.map((line, idx) => {
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith('# ')) {
+      return (
+        <Text
+          key={idx}
+          style={{ fontSize: 20, fontWeight: 'bold', marginBottom: 10 }}
+        >
+          {trimmed.replace('# ', '')}
+        </Text>
+      );
+    }
+
+    if (trimmed.startsWith('## ')) {
+      return (
+        <Text
+          key={idx}
+          style={{ fontSize: 16, fontWeight: 'bold', marginBottom: 8 }}
+        >
+          {trimmed.replace('## ', '')}
+        </Text>
+      );
+    }
+
+    if (trimmed.startsWith('- ')) {
+      return (
+        <Text key={idx} style={{ fontSize: 12, marginLeft: 10 }}>
+          • {trimmed.replace('- ', '')}
+        </Text>
+      );
+    }
+
+    if (trimmed === '') {
+      return (
+        <Text key={idx} style={{ marginBottom: 10 }}>
+          {' '}
+        </Text>
+      );
+    }
+
+    return (
+      <Text key={idx} style={{ fontSize: 12, marginBottom: 4 }}>
+        {trimmed}
+      </Text>
+    );
+  });
+};


### PR DESCRIPTION
## 🔍 관련 이슈
- close #75 


## 🌏 Summary
가이드보기를 클릭시 온보딩 모달 띄우기 (완료)

+ 유진님이 말씀하신 온보딩 하단에 뜨는 이슈
디자인 주신걸로 반영했습니다

**요약문 pdf 변환 -> md형식으로 (아까 상의했듯, 좀 고민이 필요합니다)**

문제 선택시 에러처리 (직접 입력 선택시 숫자 입력 기능) (완료)
-> 숫자가 아닌 값을 넣었을 경우
-> 20 초과하는 값을 넣었을 경우
-> 0을 넣었을 경우

이 3가지를 분기해서 toast.error 처리하였고,
사용자 경험을 위해 다른 종류의 error가 온다면
dismiss 처리했습니다.

폴더 삭제 시 삭제 바로 전 모달 보여주기 (완료)
-> 기존에 있는 Modal 컴포넌트 재사용했습니다.

## 📸 스크린샷

<img width="947" alt="스크린샷 2025-06-28 오전 5 17 34" src="https://github.com/user-attachments/assets/7d2bda7e-7c97-4dae-a150-77b66c810c96" />



홈페이지 FC에 살짝 너무 책임이 많다는 생각이 들기는 합니다.
가능하다면, 약간 분산을 시켜도 좋을 것같아요.

또한 전에 온보딩 모달 올라간 pr이랑 일부로 겹칩니다.
이 PR만 반영해도 좋습니다. (어차피 이전 PR 내용이 들어가있습니다.)
